### PR TITLE
Use qualified namespace

### DIFF
--- a/src/Casts/MoneyCast.php
+++ b/src/Casts/MoneyCast.php
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Andriichuk\Laracash\Facades\Laracash;
 use Illuminate\Database\Eloquent\Model;
 use Money\Currency;
-use Money\Money;
 
 /**
  * Class MoneyCast
@@ -25,10 +24,10 @@ final class MoneyCast implements CastsAttributes
      *
      * @param \Illuminate\Contracts\Database\Eloquent\Model $model
      * @param string $key
-     * @param Money|string|int $value
+     * @param \Money\Money|string|int $value
      * @param array $attributes
      *
-     * @return Money
+     * @return \Money\Money
      */
     public function get($model, $key, $value, $attributes)
     {
@@ -40,7 +39,7 @@ final class MoneyCast implements CastsAttributes
      *
      * @param \Illuminate\Database\Eloquent\Model $model
      * @param string $key
-     * @param Money|string|int $value
+     * @param \Money\Money|string|int $value
      * @param array $attributes
      *
      * @return array|string


### PR DESCRIPTION
I use this https://github.com/barryvdh/laravel-ide-helper with PHPstorm


laracash version: v0.0.9

actual behavior:
when run 
```
            "Illuminate\\Foundation\\ComposerScripts::postUpdate",
            "@php artisan ide-helper:generate --ansi",
            "@php artisan ide-helper:meta --ansi",
            "@php artisan ide-helper:models --reset --write --ansi",
            "@php artisan inspire --ansi"
```

models will result something like this
```php
/**
 * App\Models\Product\Product
 *
 * @property int $id
 * @property int $product_category_id
 * @property string $sku
 * @property string $title
 * @property string $description
 * @property \Money $price manage by moneyphp/money   << -----------------------------------------------
 * @property int $minimum_quantity zero mean no limit
 * @property int|null $stock
```


FIx behavior output

```php
/**
 * App\Models\Product\Product
 *
 * @property int $id
 * @property int $product_category_id
 * @property string $sku
 * @property string $title
 * @property string $description
 * @property \Money\Money $price manage by moneyphp/money  << ---------------------------
 * @property int $minimum_quantity zero mean no limit
 * @property int|null $stock
```

Thanks